### PR TITLE
Changed German name

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Schlichter App Launcher</string>
+    <string name="app_name">Schlichter AppLauncher</string>
     <string name="app_launcher_name">App Launcher</string>
     <string name="delete">Löschen</string>
     <string name="edit">Bearbeiten</string>


### PR DESCRIPTION
Removed whitespace so that the German title will be shown correctly. Until now, the name was cut right after 'Launche' so obviously the r was missing.