### PR TITLE
Revert from using the bottom action menu

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/applauncher/adapters/LaunchersAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/applauncher/adapters/LaunchersAdapter.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.applauncher.adapters
 
+import android.view.Menu
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -24,7 +25,6 @@ import com.simplemobiletools.commons.interfaces.ItemTouchHelperContract
 import com.simplemobiletools.commons.interfaces.RefreshRecyclerViewListener
 import com.simplemobiletools.commons.interfaces.StartReorderDragListener
 import com.simplemobiletools.commons.views.MyRecyclerView
-import com.simplemobiletools.commons.views.bottomactionmenu.BottomActionMenuView
 import kotlinx.android.synthetic.main.item_app_launcher.view.*
 import java.util.*
 import kotlin.collections.ArrayList
@@ -52,8 +52,10 @@ class LaunchersAdapter(
 
     override fun getActionMenuId() = R.menu.cab
 
-    override fun onBottomActionMenuCreated(view: BottomActionMenuView) {
-        view.toggleItemVisibility(R.id.cab_edit, isOneItemSelected())
+    override fun prepareActionMode(menu: Menu) {
+        menu.apply {
+            findItem(R.id.cab_edit).isVisible = isOneItemSelected()
+        }
     }
 
     override fun actionItemPressed(id: Int) {


### PR DESCRIPTION
- This revert from using the previously added bottom action menu.
- The app will use the top contextual action menu pending when the implementation for the bottom action menu is complete